### PR TITLE
Support multiple projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 **/*.swp
 **/*~
+.vscode/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ snyk-github-issue-creator [--snykOrg=<snykOrg> --snykProject=<snykProject> | -
 -   The optional `projectName` allows to overrride the project name from Snyk (useful when runing Snyk with CI/CLI integration)
 -   If `parseManifestName` is specified, the dependency paths will start with the manifest name instead of the project name
 -   If `batch` is specified, the selected findings will be combined into a single GitHub issue (see this [example](screenshot-issue-batch.png))
+-   If `severityLabel` is specified, the GitHub issue will have severity label(s) added
 
 You will be presented with a list of _high_ and _medium_ vulnerability issues to
 generate a GitHub issue for. Type `t` or `true` to create an issue,

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ snyk-github-issue-creator [--snykOrg=<snykOrg> --snykProject=<snykProject> | -
 -   You can retrieve your snykOrg Id from your org settings page on [Snyk](https://snyk.io) or via the [Snyk API](https://snyk.docs.apiary.io/#reference/organisations/the-snyk-organisation-for-a-request/list-all-the-organisations-a-user-belongs-to).
 -   The SnykProject Id is available via the [Snyk API](https://snyk.docs.apiary.io/#reference/projects/projects-by-organisation/list-all-projects).
 -   You need to either provide a valid `SnykOrg` Id and `snykProject` Id, or use the `stdin` option to parse the output of a snyk monitor command to retrieve the necessary parameters.
+    -   If using `snykProject`, you can specify multiple project Ids separated by spaces
 -   The optional `projectName` allows to overrride the project name from Snyk (useful when runing Snyk with CI/CLI integration)
 -   If `parseManifestName` is specified, the dependency paths will start with the manifest name instead of the project name
 -   If `batch` is specified, the selected findings will be combined into a single GitHub issue (see this [example](screenshot-issue-batch.png))

--- a/cli/batch.js
+++ b/cli/batch.js
@@ -63,9 +63,6 @@ const getBatchIssue = async (issues) => {
         acc[cur.severity] = (acc[cur.severity] || []).concat(cur);
         return acc;
     }, {});
-    const severities = Object.keys(sevMap)
-        .map((sev) => capitalize(sev))
-        .join(`/`);
     const batchProps = await getBatchProps(issues);
 
     // if there is a single vulnerability, just use that for the description
@@ -81,7 +78,7 @@ const getBatchIssue = async (issues) => {
     const projects = getProjects(issues);
     const title = `${getProjectName(projects)} - ${description} in ${
         batchProps.package
-    } ${batchProps.version} (${severities})`;
+    } ${batchProps.version}`;
 
     const headerText = `This issue has been created automatically by a source code scanner.\r\n\r\nSnyk project(s):`;
     const projectText = projects

--- a/cli/index.js
+++ b/cli/index.js
@@ -331,13 +331,13 @@ function getIssueTitle(project, issue) {
 function getIssueBody(project, issue) {
     return `This issue has been created automatically by a source code scanner
 
-  ## Third party component with known security vulnerabilities
+## Third party component with known security vulnerabilities
 
-  Introduced to ${getProjectName(project)} through:
+Introduced to ${getProjectName(project)} through:
 
-  ${getGraph(project, issue, '* ')}
+${getGraph(project, issue, '* ')}
 
-  ${issue.description}
+${issue.description}
 - [SNYKUID:${issue.id}](${issue.url})
 `;
 }

--- a/cli/index.js
+++ b/cli/index.js
@@ -7,9 +7,9 @@ const args = require('minimist')(process.argv.slice(2));
 const request = require('request-promise-native');
 const chalk = require('chalk');
 
-const { getBatchProps } = require('./batch');
+const { getBatchProps, getBatchIssue } = require('./batch');
 const parseAndValidateInput = require('./input');
-const { capitalize, compareText, uniq } = require('./utils');
+const { compareText, getProjectName, getGraph } = require('./utils');
 
 const snykBaseUrl = 'https://snyk.io/api/v1';
 
@@ -189,8 +189,7 @@ async function createIssues() {
     const issueQuestions = [];
 
     let ctr = 0;
-    console.log(`Found ${issues.length} vulnerabilities:
-`);
+    console.log(`Found ${issues.length} vulnerabilities:\n`);
     issues.forEach((issue, i) => {
         const description = `${i + 1}. ${issue.package} ${issue.version} - ${
             issue.title
@@ -217,28 +216,6 @@ ${getGraph(project, issue, ' * ')}
     await generateGhIssues(project, issuesToAction);
 
     process.exit(0);
-}
-
-function getProjectName(project) {
-    return typeof args.projectName !== 'undefined'
-        ? args.projectName
-        : project.name;
-}
-
-function getManifestName(project) {
-    if (args.parseManifestName) {
-        return project.name.substring(project.name.indexOf(':') + 1);
-    }
-    return getProjectName(project);
-}
-
-function getGraph(project, issue, prefix) {
-    return issue.from
-        .map(
-            (paths) =>
-                `${prefix}${getManifestName(project)} > ${paths.join(' > ')}`
-        )
-        .join('\r\n');
 }
 
 // Must include Snyk id to distinguish between issues within the same component, that might have different mitigation
@@ -268,66 +245,17 @@ async function generateGhIssues(project, issues, existingMap = new Map()) {
         typeof args.ghLabels !== 'undefined' ? args.ghLabels.split(',') : [];
     labels.push('snyk');
 
-    const projectName = getProjectName(project);
     let ghNewIssues = [];
     let ghUpdatedIssues = [];
     if (batch && issues.length) {
-        const sevMap = issues.reduce((acc, cur) => {
-            acc[cur.severity] = (acc[cur.severity] || []).concat(cur);
-            return acc;
-        }, {});
-        const severities = Object.keys(sevMap)
-            .map((sev) => capitalize(sev))
-            .join(`/`);
-        const batchProps = await getBatchProps(issues);
-
-        // if there is a single vulnerability, just use that for the description
-        let description = `${issues[0].title}`;
-        if (issues.length > 1) {
-            // otherwise, if there are multiple vulnerabilities:
-            const titles = uniq(issues.map((x) => x.title));
-            const vuln = titles.length === 1 ? ` ${titles[0]}` : '';
-            // if there are multiple of vulnerabilities of a single type, include the type in the description
-            // otherwise, if there are multiple types of vulnerabilities of a multiple types, leave that out of the description
-            description = `${issues.length}${vuln} findings`;
-        }
-        const title = `${getProjectName(project)} - ${description} in ${
-            batchProps.package
-        } ${batchProps.version} (${severities})`;
-
-        const text = Object.keys(sevMap)
-            .map((sev) => {
-                const header = `# ${capitalize(sev)}-severity vulnerabilities`;
-                const body = sevMap[sev]
-                    .map(
-                        (issue, i) =>
-                            `\r\n\r\n<details>
-<summary>${i + 1}. ${issue.title} in ${issue.package} ${issue.version} (${
-                                issue.id
-                            })</summary>
-
-## Detailed paths
-${getGraph(project, issue, '* ')}
-
-${issue.description}
-- [${issue.id}](${issue.url})
-</details>`
-                    )
-                    .join('');
-                return header + body;
-            })
-            .join('\r\n\r\n');
+        const { title, body } = await getBatchIssue(project, issues);
 
         ghNewIssues = [
             await octokit.issues.create({
                 owner: ghOwner,
                 repo: ghRepo,
                 title,
-                body: `This issue has been created automatically by a source code scanner.
-
-Snyk project: [\`${project.name}\`](${project.browseUrl}) (manifest version ${project.imageTag})
-
-${text}`,
+                body,
                 labels,
             }),
         ];

--- a/cli/input.js
+++ b/cli/input.js
@@ -1,0 +1,82 @@
+const chalk = require('chalk');
+const fs = require('fs');
+const uuidValidate = require('uuid-validate');
+
+const parseAndValidateInput = (args) => {
+    const help =
+        'Usage: snyk-github-issue-creator [--snykOrg=<snykOrg> --snykProject=<snykProject> | --stdin ] ' +
+        '--ghOwner=<ghOwner> --ghRepo=<ghRepo> ' +
+        '[--ghLabels=<ghLabel>,...] [--projectName=<projectName>] [--parseManifestName] [--batch] [--autoGenerate]';
+
+    if (args.help || args.h) {
+        console.log(help);
+        return process.exit(0);
+    }
+
+    const errors = [];
+    const parseArgument = (key, options) => {
+        const { isEnvVar = false, errSuffix = '' } = options || {};
+        const value = isEnvVar ? process.env[key] : args[key];
+        if (!value) {
+            const type = isEnvVar ? 'environment variable' : 'argument';
+            errors.push(`"${key}" ${type} must be non-empty ${errSuffix}`);
+        }
+        return value;
+    };
+
+    const snykToken = parseArgument('SNYK_TOKEN', { isEnvVar: true });
+    const ghPat = parseArgument('GH_PAT', { isEnvVar: true });
+    const ghOwner = parseArgument('ghOwner');
+    const ghRepo = parseArgument('ghRepo');
+    let snykOrg;
+    let snykProject;
+
+    // snykOrg and snykProject either come from stdin, or from separate CLI arguments
+    if (args.stdin) {
+        const stdin = fs.readFileSync('/dev/stdin').toString();
+        stdin.split('\n').forEach((line) => {
+            const matched = line.match(
+                /^Explore this snapshot at https:\/\/app.snyk.io\/org\/([^\/]+)\/project\/([^\/]+)\/.*/
+            );
+            if (matched && matched.length == 3) {
+                snykOrg = matched[1];
+                snykProject = matched[2];
+            }
+        });
+        if (
+            typeof snykOrg === 'undefined' ||
+            !snykOrg ||
+            typeof snykProject === 'undefined' ||
+            !snykProject
+        ) {
+            console.error(
+                chalk.red(
+                    'Could not parse required Snyk Org and Snyk Project from stdin.'
+                )
+            );
+            process.exit(1);
+        }
+    } else {
+        const errSuffix = 'if the "stdin" argument is not used';
+        snykOrg = parseArgument('snykOrg', { errSuffix });
+        snykProject = args.snykProject;
+        if (!uuidValidate(snykProject)) {
+            errors.push(
+                `"snykProject" argument must be a valid UUID ${errSuffix}`
+            );
+        }
+    }
+
+    if (errors.length > 0) {
+        const delim = '\n  * ';
+        console.error(
+            chalk.red(`Invalid usage: ${delim}${errors.join(delim)}`)
+        );
+        console.log(help);
+        return process.exit(1);
+    }
+
+    return { snykToken, ghPat, ghOwner, ghRepo, snykOrg, snykProject };
+};
+
+module.exports = parseAndValidateInput;

--- a/cli/input.js
+++ b/cli/input.js
@@ -29,7 +29,7 @@ const parseAndValidateInput = (args) => {
     const ghOwner = parseArgument('ghOwner');
     const ghRepo = parseArgument('ghRepo');
     let snykOrg;
-    let snykProject;
+    let snykProjects;
 
     // snykOrg and snykProject either come from stdin, or from separate CLI arguments
     if (args.stdin) {
@@ -40,14 +40,14 @@ const parseAndValidateInput = (args) => {
             );
             if (matched && matched.length == 3) {
                 snykOrg = matched[1];
-                snykProject = matched[2];
+                snykProjects = [matched[2]];
             }
         });
         if (
             typeof snykOrg === 'undefined' ||
             !snykOrg ||
-            typeof snykProject === 'undefined' ||
-            !snykProject
+            typeof snykProjects[0] === 'undefined' ||
+            !snykProjects[0]
         ) {
             console.error(
                 chalk.red(
@@ -59,10 +59,12 @@ const parseAndValidateInput = (args) => {
     } else {
         const errSuffix = 'if the "stdin" argument is not used';
         snykOrg = parseArgument('snykOrg', { errSuffix });
-        snykProject = args.snykProject;
-        if (!uuidValidate(snykProject)) {
+        snykProjects =
+            args.snykProject &&
+            args.snykProject.split(' ').filter((x) => uuidValidate(x));
+        if (!snykProjects || !snykProjects.length) {
             errors.push(
-                `"snykProject" argument must be a valid UUID ${errSuffix}`
+                `"snykProject" argument must be one or more valid UUIDs (separated by spaces) ${errSuffix}`
             );
         }
     }
@@ -76,7 +78,7 @@ const parseAndValidateInput = (args) => {
         return process.exit(1);
     }
 
-    return { snykToken, ghPat, ghOwner, ghRepo, snykOrg, snykProject };
+    return { snykToken, ghPat, ghOwner, ghRepo, snykOrg, snykProjects };
 };
 
 module.exports = parseAndValidateInput;

--- a/cli/labels.js
+++ b/cli/labels.js
@@ -1,0 +1,70 @@
+const args = require('minimist')(process.argv.slice(2));
+const { uniq } = require('./utils');
+
+const LABELS = {
+    snyk: {
+        description: 'Issue reported by Snyk Open Source scanner',
+        color: '70389f',
+    },
+    'severity:high': {
+        description: 'High severity rating',
+        color: 'b31a6b',
+    },
+    'severity:medium': {
+        description: 'Medium severity rating',
+        color: 'df8620',
+    },
+    'severity:low': {
+        description: 'Low severity rating',
+        color: '595775',
+    },
+};
+const DEFAULT_LABEL = {
+    description: '',
+    color: 'ffffff',
+};
+
+const getLabels = (issueOrIssues) => {
+    let labels = args.ghLabels ? args.ghLabels.split(',') : [];
+    labels.push('snyk');
+    if (args.severityLabel) {
+        const issues = Array.isArray(issueOrIssues) ? issueOrIssues : [];
+        const severities = uniq(issues.map((x) => `severity:${x.severity}`));
+        labels = labels.concat(severities);
+    }
+    return labels;
+};
+
+const getLabelAttributes = (name) => {
+    return { name, ...(LABELS[name] || DEFAULT_LABEL) };
+};
+
+const ensureLabelsAreCreated = async (octokit, ghOwner, ghRepo, issues) => {
+    const labels = getLabels(issues);
+    const response = await octokit.issues.listLabelsForRepo({
+        owner: ghOwner,
+        repo: ghRepo,
+        per_page: 100,
+    });
+    const currentLabels = response.data.map((x) => x.name);
+    const labelsToCreate = labels.filter((x) => !currentLabels.includes(x));
+    if (!labelsToCreate.length) {
+        return;
+    }
+
+    await Promise.all(
+        labelsToCreate.map((name) =>
+            octokit.issues
+                .createLabel({
+                    owner: ghOwner,
+                    repo: ghRepo,
+                    ...getLabelAttributes(name),
+                })
+                .then(() => {
+                    console.log(`Created GitHub label: "${name}"`);
+                })
+        )
+    );
+};
+
+module.exports = { getLabels, ensureLabelsAreCreated };

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -18,10 +18,14 @@ const capitalize = (s) => {
 
 const uniq = (array) => [...new Set(array)];
 
-const getProjectName = (project) => {
-    return typeof args.projectName !== 'undefined'
-        ? args.projectName
-        : project.name;
+const getProjectName = (projectOrProjects) => {
+    if (args.projectName) {
+        return args.projectName;
+    } else if (Array.isArray(projectOrProjects)) {
+        return `${projectOrProjects.length} projects`;
+    }
+    // single project
+    return projectOrProjects.name;
 };
 
 const getManifestName = (project) => {
@@ -31,10 +35,10 @@ const getManifestName = (project) => {
     return getProjectName(project);
 };
 
-const getGraph = (project, issue, prefix) => {
+const getGraph = (issue, prefix) => {
     return issue.from
         .map(
-            (paths) =>
+            ({ project, paths }) =>
                 `${prefix}${getManifestName(project)} > ${paths.join(' > ')}`
         )
         .join('\r\n');

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -1,15 +1,15 @@
 const args = require('minimist')(process.argv.slice(2));
+const semver = require('semver');
 
-const compareText = (a, b) => {
-    const _a = a.toLowerCase();
-    const _b = b.toLowerCase();
-    if (_a < _b) {
-        return -1;
-    } else if (_a > _b) {
-        return 1;
-    }
-    return 0;
-};
+// ascending order
+const compareText = (a, b) => a.toLowerCase().localeCompare(b.toLowerCase());
+
+// descending order
+const compareVersions = (a, b) =>
+    semver.lt(a, b) ? 1 : semver.gt(a, b) ? -1 : 0;
+
+// ascending order
+const compareArrays = (a, b) => compareText(a.join(), b.join());
 
 const capitalize = (s) => {
     if (typeof s !== 'string') return '';
@@ -46,7 +46,11 @@ const getGraph = (issue, prefix) => {
 
 module.exports = {
     capitalize,
-    compareText,
+    compare: {
+        text: compareText,
+        versions: compareVersions,
+        arrays: compareArrays,
+    },
     uniq,
     getProjectName,
     getGraph,

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -1,3 +1,5 @@
+const args = require('minimist')(process.argv.slice(2));
+
 const compareText = (a, b) => {
     const _a = a.toLowerCase();
     const _b = b.toLowerCase();
@@ -16,8 +18,32 @@ const capitalize = (s) => {
 
 const uniq = (array) => [...new Set(array)];
 
+const getProjectName = (project) => {
+    return typeof args.projectName !== 'undefined'
+        ? args.projectName
+        : project.name;
+};
+
+const getManifestName = (project) => {
+    if (args.parseManifestName) {
+        return project.name.substring(project.name.indexOf(':') + 1);
+    }
+    return getProjectName(project);
+};
+
+const getGraph = (project, issue, prefix) => {
+    return issue.from
+        .map(
+            (paths) =>
+                `${prefix}${getManifestName(project)} > ${paths.join(' > ')}`
+        )
+        .join('\r\n');
+};
+
 module.exports = {
     capitalize,
     compareText,
     uniq,
+    getProjectName,
+    getGraph,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,6 +261,13 @@
                 "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
         },
         "dashdash": {
@@ -469,6 +476,11 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+        },
         "macos-release": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
@@ -633,9 +645,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+            "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
         },
         "shebang-command": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,16 @@
     "author": "pierre-ernst",
     "license": "ISC",
     "dependencies": {
+        "@octokit/plugin-throttling": "^3.2.0",
+        "@octokit/rest": "^17.0.0",
         "chalk": "^3.0.0",
         "enquirer": "^2.3.4",
+        "lodash.flatten": "^4.4.0",
         "minimist": "^1.2.3",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.8",
-        "uuid-validate": "^0.0.3",
-        "@octokit/rest": "^17.0.0",
-        "@octokit/plugin-throttling": "^3.2.0"
+        "semver": "^7.1.3",
+        "uuid-validate": "^0.0.3"
     },
     "devDependencies": {
         "prettier": "2.0.1"


### PR DESCRIPTION
This PR adds support for multiple projects. Identical issues for different projects will be reduced/combined, but each project will be reflected in the "detailed paths" that is shown in the issue description.

This PR also changes how issues are reduced -- two identical issues of the same package / different versions will **not** be reduced together.

Also: added a new argument to include "severity" labels on newly created GitHub issues. If batching is used, multiple severity labels may be applied.