### PR TITLE
Show more descriptive dependency paths

### DIFF
--- a/cli/batch.js
+++ b/cli/batch.js
@@ -6,6 +6,7 @@ const {
     compare,
     uniq,
     getProjectName,
+    getUniqueProjectNamePrefixes,
     getGraph,
 } = require('./utils');
 
@@ -76,6 +77,7 @@ const getBatchIssue = async (issues) => {
         description = `${issues.length}${vuln} findings`;
     }
     const projects = getProjects(issues);
+    const showFullManifest = getUniqueProjectNamePrefixes(projects).size > 1;
     const title = `${getProjectName(projects)} - ${description} in ${
         batchProps.package
     } ${batchProps.version}`;
@@ -99,7 +101,7 @@ const getBatchIssue = async (issues) => {
                         })</summary>
 
 ## Detailed paths
-${getGraph(issue, '* ')}
+${getGraph(issue, '* ', showFullManifest)}
 
 ${issue.description}
 - [${issue.id}](${issue.url})

--- a/cli/index.js
+++ b/cli/index.js
@@ -193,7 +193,7 @@ async function createIssues() {
             issue.title
         }`;
         console.log(`${description} - ${issue.id} (${issue.severity})
-${getGraph(issue, ' * ')}
+${getGraph(issue, ' * ', true)}
 `);
         issueQuestions.push({
             type: 'confirm',

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -28,19 +28,32 @@ const getProjectName = (projectOrProjects) => {
     return projectOrProjects.name;
 };
 
-const getManifestName = (project) => {
+const getManifestName = (project, showManifestPrefix) => {
     if (args.parseManifestName) {
+        if (showManifestPrefix) {
+            return project.name;
+        }
         return project.name.substring(project.name.indexOf(':') + 1);
     }
     return getProjectName(project);
 };
 
-const getGraph = (issue, prefix) => {
+const getUniqueProjectNamePrefixes = (projects) =>
+    new Set(projects.map(({ name }) => name.substring(0, name.indexOf(':'))));
+
+const getGraph = (issue, prefix, showFullManifest) => {
+    const uniqueProjectNamePrefixes = getUniqueProjectNamePrefixes(
+        issue.from.map(({ project }) => project)
+    );
+    const isMultipleBranches = uniqueProjectNamePrefixes.size > 1;
     return issue.from
-        .map(
-            ({ project, paths }) =>
-                `${prefix}${getManifestName(project)} > ${paths.join(' > ')}`
-        )
+        .map(({ project, paths }) => {
+            const root = getManifestName(
+                project,
+                isMultipleBranches || showFullManifest
+            );
+            return `${prefix}${root} > ${paths.join(' > ')}`;
+        })
         .join('\r\n');
 };
 
@@ -53,5 +66,6 @@ module.exports = {
     },
     uniq,
     getProjectName,
+    getUniqueProjectNamePrefixes,
     getGraph,
 };


### PR DESCRIPTION
When issue dependency paths are shown, they may be sourced from multiple projects (either in the CLI or in GitHub, depending on how the tool is used). Multiple projects may have different prefixes to denote that they are sourced from a different code branch. This commit intelligently shows that prefix in the dependency paths when necessary.