### PR TITLE
Fix project name

### DIFF
--- a/cli/utils.js
+++ b/cli/utils.js
@@ -22,6 +22,10 @@ const getProjectName = (projectOrProjects) => {
     if (args.projectName) {
         return args.projectName;
     } else if (Array.isArray(projectOrProjects)) {
+        if (projectOrProjects.length === 1) {
+            // single project
+            return projectOrProjects[0].name;
+        }
         return `${projectOrProjects.length} projects`;
     }
     // single project


### PR DESCRIPTION
When scanning a single project using `batch` mode (without the `projectName` override flag), it would use "1 projects" as the project name instead of the single project's name.